### PR TITLE
ci: Reuse built package when building userscripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |
-          npm install ${{ steps.download.outputs.download-path }}/userscript-metadata-*.tgz
+          npm install ${{ steps.download.outputs.download-path }}/package-tarball/userscript-metadata-*.tgz
       - name: Build userscript
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,16 @@ jobs:
           npm run build
         env:
           CI: true
+      - name: Pack
+        id: pack
+        run: |
+          echo "::set-output name=tarball::$(pwd)/$(npm pack)"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.node-version == 'lts/*' }}
+        with:
+          name: package-tarball
+          path: ${{ steps.pack.outputs.tarball }}
   userscripts:
     name: Dependent Userscripts
     runs-on: ubuntu-latest
@@ -48,16 +58,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: |
-          npm ci
-      - name: Build
-        run: |
-          npm run build
-      - name: Pack
-        id: pack
-        run: |
-          echo "::set-output name=tarball::$(pwd)/$(npm pack)"
       - name: Clone userscript
         uses: actions/checkout@v2
         with:
@@ -73,10 +73,15 @@ jobs:
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |
           npm ci
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: package-tarball
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |
-          npm install "${{ steps.pack.outputs.tarball }}"
+          npm install "${{ steps.download.outputs.download-path }}/userscript-metadata-*.tgz"
       - name: Build userscript
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
           path: ${{ steps.pack.outputs.tarball }}
   userscripts:
     name: Dependent Userscripts
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         id: download
+      - name: Show downloaded files
+        run: ls -R
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/download-artifact@v3
         id: download
       - name: Show downloaded files
-        run: ls -R
+        run: pwd && ls -R
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,6 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         id: download
-      - name: Show downloaded files
-        run: pwd && ls -R
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |
-          npm install "${{ steps.download.outputs.download-path }}/userscript-metadata-*.tgz"
+          npm install ${{ steps.download.outputs.download-path }}/userscript-metadata-*.tgz
       - name: Build userscript
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,6 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         id: download
-        with:
-          name: package-tarball
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: package-tarball
+          name: built-package
           path: ${{ steps.pack.outputs.tarball }}
   userscripts:
     name: Dependent Userscripts
@@ -76,7 +76,7 @@ jobs:
       - name: Install userscript-metadata
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |
-          npm install ${{ steps.download.outputs.download-path }}/package-tarball/userscript-metadata-*.tgz
+          npm install ${{ steps.download.outputs.download-path }}/built-package/userscript-metadata-*.tgz
       - name: Build userscript
         working-directory: ${{ runner.temp }}/${{ matrix.repository }}
         run: |


### PR DESCRIPTION
Instead of building this package in every Dependent Userscripts job (currently 8 of them), this PR makes them use the package built in the CI Build job.

💡 `git show --color-moved` is useful.