### PR TITLE
ci: Build only with latest Node.js LTS version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,15 +12,12 @@ jobs:
   build:
     name: CI Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use latest Node.js LTS version
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
What matters is that the library can be _used_ on different Node versions.